### PR TITLE
decouple server from namer, reuse for a tpdb fake

### DIFF
--- a/namer/types.py
+++ b/namer/types.py
@@ -16,10 +16,8 @@ from pathlib import Path, PurePath
 from typing import List, Optional, Sequence
 
 from loguru import logger
-from pathvalidate._common import Platform
-from pathvalidate._filename import sanitize_filename
-from requests_cache import BACKEND_CLASSES, CachedSession
-from requests_cache.backends.base import BaseCache
+from pathvalidate import Platform, sanitize_filename 
+from requests_cache import BACKEND_CLASSES, BaseCache, CachedSession
 
 
 def _verify_name_string(name: str, name_string: str) -> bool:

--- a/namer/types.py
+++ b/namer/types.py
@@ -16,8 +16,10 @@ from pathlib import Path, PurePath
 from typing import List, Optional, Sequence
 
 from loguru import logger
-from pathvalidate import Platform, sanitize_filename
-from requests_cache import BACKEND_CLASSES, BaseCache, CachedSession
+from pathvalidate._common import Platform
+from pathvalidate._filename import sanitize_filename
+from requests_cache import BACKEND_CLASSES, CachedSession
+from requests_cache.backends.base import BaseCache
 
 
 def _verify_name_string(name: str, name_string: str) -> bool:

--- a/namer/types.py
+++ b/namer/types.py
@@ -16,7 +16,7 @@ from pathlib import Path, PurePath
 from typing import List, Optional, Sequence
 
 from loguru import logger
-from pathvalidate import Platform, sanitize_filename 
+from pathvalidate import Platform, sanitize_filename
 from requests_cache import BACKEND_CLASSES, BaseCache, CachedSession
 
 

--- a/namer/web/server.py
+++ b/namer/web/server.py
@@ -39,11 +39,9 @@ class WebServer:
         self.__path = '/' if not self.__webroot else self.__webroot
         self.__app = Flask(__name__, static_url_path=self.__path, static_folder=static_url, template_folder='templates')
         self.__blueprints = blueprints
-
         self.__add_mime_types()
         self.__register_blueprints()
         self.__make_server()
-        print(self.__app.url_map)
 
     def __make_server(self):
         self.__compress.init_app(self.__app)

--- a/namer/web/server.py
+++ b/namer/web/server.py
@@ -32,21 +32,22 @@ class WebServer:
         'font/woff2': '.woff2',
     }
 
-    def __init__(self, host: str, port: int, webroot: Optional[str], blueprints: List[Blueprint]):
+    def __init__(self, host: str, port: int, webroot: Optional[str], blueprints: List[Blueprint], static_url: Optional[str] = 'public'):
         self.__host = host
         self.__port = port
         self.__webroot = webroot
         self.__path = '/' if not self.__webroot else self.__webroot
-        self.__app = Flask(__name__, static_url_path=self.__path, static_folder='public', template_folder='templates')
+        self.__app = Flask(__name__, static_url_path=self.__path, static_folder=static_url, template_folder='templates')
         self.__blueprints = blueprints
 
         self.__add_mime_types()
         self.__register_blueprints()
         self.__make_server()
+        print(self.__app.url_map)
 
     def __make_server(self):
         self.__compress.init_app(self.__app)
-        self.__server = create_server(self.__app, host=self.__host, port=self.__port)
+        self.__server = create_server(self.__app, host=self.__host, port=self.__port, clear_untrusted_proxy_headers=True)
         self.__thread = Thread(target=self.__run, daemon=True)
 
     def __register_blueprints(self):
@@ -81,3 +82,6 @@ class WebServer:
 
     def get_effective_port(self) -> Optional[int]:
         return getattr(self.__server, "effective_port", None)
+
+    def get_url(self) -> str:
+        return f"http://{self.__host}:{self.get_effective_port()}{self.__webroot}"

--- a/test/web/fake_tpdb.py
+++ b/test/web/fake_tpdb.py
@@ -1,0 +1,8 @@
+from test.web.parrot_webserver import ParrotWebserver
+
+
+def make_fake_tpbd() -> ParrotWebserver:
+    server = ParrotWebserver()
+    # start setting up the server
+    # server.set_response( url, bytearray())
+    return server

--- a/test/web/namer_web_pageobjects.py
+++ b/test/web/namer_web_pageobjects.py
@@ -164,7 +164,7 @@ class FailedItem():
 
 
 class FailedPage():
-    __driver = WebDriver
+    __driver: WebDriver
     __refresh: WebElement
     __search: Optional[WebElement]
     __failed_table: Optional[WebElement]
@@ -174,7 +174,6 @@ class FailedPage():
         self.__driver = driver
         self.__refresh = self.__driver.find_element(by=By.ID, value='refreshFiles')
         self.__search = next(iter(self.__driver.find_elements(by=By.CSS_SELECTOR, value='input[type="search"]')), None)
-        self.__failed_table = next(iter(self.__driver.find_elements(by=By.CSS_SELECTOR, value='table[id="failed"]')), None)
         self.__items = self.__driver.find_elements(by=By.CSS_SELECTOR, value='table[id="failed"] tbody tr')
 
     def navigate_to(self) -> NavElements:

--- a/test/web/namer_web_pageobjects.py
+++ b/test/web/namer_web_pageobjects.py
@@ -1,6 +1,8 @@
 from typing import Generic, List, Optional, TypeVar
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from assertpy import assert_that, fail
 from assertpy.assertpy import AssertionBuilder
@@ -32,7 +34,10 @@ class NavElements():
 
     def __init__(self, driver: WebDriver):
         self.__driver = driver
-        # WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, 'a[href="./settings"]')))
+        # wait until loaded
+        wait = WebDriverWait(driver, 10)
+        wait.until(EC.element_to_be_clickable((By.CSS_SELECTOR, 'a[href="./settings"]')))
+
         self.__failed: WebElement = self.__driver.find_element(by=By.CSS_SELECTOR, value='a[href="./failed"]')
         self.__queue: WebElement = self.__driver.find_element(by=By.CSS_SELECTOR, value='a[href="./queue"]')
         self.__config: WebElement = self.__driver.find_element(by=By.CSS_SELECTOR, value='a[href="./settings"]')
@@ -197,9 +202,11 @@ class FailedPage():
 
 class QueuePage():
     __driver: WebDriver
+    __refresh: WebElement
 
     def __init__(self, driver: WebDriver):
         self.__driver = driver
+        self.__refresh = self.__driver.find_element(by=By.ID, value='refreshFiles')
 
     def navigate_to(self) -> NavElements:
         return NavElements(self.__driver)

--- a/test/web/namer_web_test.py
+++ b/test/web/namer_web_test.py
@@ -8,9 +8,15 @@ from platform import system
 from sys import gettrace as sys_gettrace
 from unittest.mock import MagicMock, patch
 
-from selenium.webdriver import Chrome, ChromeOptions
-from selenium.webdriver.chrome.service import Service
+
+from selenium.webdriver import Chrome, ChromeOptions, Edge, EdgeOptions, Safari
+from selenium.webdriver.safari.options import Options as SafariOptions
+from selenium.webdriver.chrome.service import Service as ChromeService
+from selenium.webdriver.edge.service import Service as EdgeService
+
+from selenium.webdriver.remote.webdriver import WebDriver
 from webdriver_manager.chrome import ChromeDriverManager
+from webdriver_manager.microsoft import EdgeChromiumDriverManager
 
 from namer.watchdog import create_watcher
 from test.namer_watchdog_test import make_locations, new_ea, prepare
@@ -21,6 +27,36 @@ from test.web.parrot_webserver import ParrotWebserver
 
 def isdebugging():
     return sys_gettrace() is not None
+
+
+def chrome_factory(debug: bool) -> WebDriver:
+    options = ChromeOptions()
+    if (system() == 'Linux' and os.environ.get("DISPLAY") is None) or not debug:
+        options.headless = True
+    if system() != 'Windows' and os.geteuid() == 0:
+        options.add_argument("--no-sandbox")
+    service = ChromeService(executable_path=ChromeDriverManager().install(), log_path=os.devnull)  # type: ignore
+    return Chrome(service=service, options=options)
+
+
+def edge_factory(debug: bool) -> WebDriver:
+    options = EdgeOptions()
+    service = EdgeService(executable_path=EdgeChromiumDriverManager().install(), log_path=os.devnull)  # type: ignore
+    webdriver = Edge(service=service, options=options)
+    return webdriver
+
+
+def safari_factory(debug: bool) -> WebDriver:
+    options = SafariOptions()
+    return Safari(options=options)
+
+
+def default_os_browser(debug: bool) -> WebDriver:
+    if (system() == 'Windows'):
+        return edge_factory(debug)
+    if (system() == 'macOS'):
+        return safari_factory(debug)
+    return chrome_factory(debug)
 
 
 @contextlib.contextmanager
@@ -34,13 +70,7 @@ def make_test_context(config: NamerConfig):
         config.work_dir = new_config.work_dir
         with create_watcher(config) as watcher:
             url = f"http://{config.host}:{watcher.get_web_port()}{config.web_root}/failed"
-            options = ChromeOptions()
-            if (system() == 'Linux' and os.environ.get("DISPLAY") is None) or not isdebugging():
-                options.headless = True
-            if system() != 'Windows' and os.geteuid() == 0:
-                options.add_argument("--no-sandbox")
-            service = Service(executable_path=ChromeDriverManager().install(), log_path=os.devnull)  # type: ignore
-            with Chrome(service=service, options=options) as browser:
+            with default_os_browser(isdebugging()) as browser:
                 browser.get(url)
                 yield (tempdir, watcher, browser)
 

--- a/test/web/parrot_webserver.py
+++ b/test/web/parrot_webserver.py
@@ -1,0 +1,55 @@
+from threading import Thread
+from time import time
+from typing import Dict, Optional
+from namer.web.server import WebServer
+from flask import Blueprint, make_response
+from flask.wrappers import Response
+
+
+def get_routes(responses: Dict[str, bytes]) -> Blueprint:
+    """
+    Builds a blueprint for flask with passed in context, the NamerConfig.
+    """
+    blueprint = Blueprint('/', __name__)
+
+    @blueprint.route('/', defaults={'path': ''})
+    @blueprint.route('/<path:path>')
+    def get_files(path) -> Response:
+        output = responses[path]
+        response = make_response(output, 200)
+        # response.mimetype = "text/plain"
+        return response
+
+    return blueprint
+
+
+class ParrotWebserver(WebServer):
+    __responses: Dict[str, bytes]
+    __background_thread: Optional[Thread]
+
+    def __init__(self):
+        self.__responses = {}
+        super().__init__("127.0.0.1", port=0, webroot="/", blueprints=[get_routes(self.__responses)], static_url=None)
+
+    def __enter__(self):
+        self.__background_thread = Thread(target=self.start)
+        self.__background_thread.start()
+        tries = 0
+        while super().get_effective_port() is None and tries < 20:
+            time.sleep(0.2)
+            tries += 1
+        if super().get_effective_port is None:
+            raise RuntimeError("application did not get assigned a port within 4 seconds.")
+        return self
+
+    def __simple_exit__(self):
+        self.stop()
+        if self.__background_thread is not None:
+            self.__background_thread.join()
+            self.__background_thread = None
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.__simple_exit__()
+
+    def set_response(self, url: str, response: bytearray):
+        self.__responses[url] = response

--- a/test/web/parrot_webserver.py
+++ b/test/web/parrot_webserver.py
@@ -1,7 +1,7 @@
 from threading import Thread
 from time import time
 from typing import Dict, Optional
-from namer.web.server import WebServer
+from namer.web.server import GenericWebServer
 from flask import Blueprint, make_response
 from flask.wrappers import Response
 
@@ -23,7 +23,7 @@ def get_routes(responses: Dict[str, bytes]) -> Blueprint:
     return blueprint
 
 
-class ParrotWebserver(WebServer):
+class ParrotWebserver(GenericWebServer):
     __responses: Dict[str, bytes]
     __background_thread: Optional[Thread]
 


### PR DESCRIPTION
Decouple webserver from namer for easy reuse.
Reuse webserver to make a ParrotWebserver.
Use ParrotWebserver for a fake tpdb for testing.

Todo: 
finish configuring response from fake tpdb
update the test to use Fake_tpdb.