### PR TITLE
Small NFO tweaks and image filename reformatting for performers

### DIFF
--- a/namer/comparison_results.py
+++ b/namer/comparison_results.py
@@ -55,6 +55,11 @@ class LookedUpFileInfo:
     porndb scene id, allowing lookup of more metadata, (tags)
     """
 
+    guid: Optional[str] = None
+    """
+    porndb guid/stashid
+    """
+
     site: Optional[str] = None
     """
     Site where this video originated, DorcelClub/Deeper/etc.....

--- a/namer/metadataapi.py
+++ b/namer/metadataapi.py
@@ -298,6 +298,7 @@ def __json_to_fileinfo(data, url: str, json_response: str, name_parts: Optional[
     url_part = data.type.lower()
     file_info.uuid = f"{url_part}s/{data_id}"
 
+    file_info.guid = data.id
     file_info.name = data.title
     file_info.description = data.description
     file_info.date = data.date

--- a/namer/moviexml.py
+++ b/namer/moviexml.py
@@ -3,7 +3,9 @@ Reads movie.xml (your.movie.name.nfo) of Emby/Jellyfin format in to a LookedUpFi
 allowing the metadata to be written in to video files (currently only mp4's),
 or used in renaming the video file.
 """
+import re
 from pathlib import Path
+
 from typing import Any, Optional, List
 from xml.dom.minidom import parseString, Document, Element
 
@@ -109,8 +111,8 @@ def write_movie_xml_file(info: LookedUpFileInfo, config: NamerConfig, trailer: O
     add_sub_element(doc, root, "mpaa", "XXX")
 
     art = add_sub_element(doc, root, "art")
-    add_sub_element(doc, art, 'poster', str(poster) if poster else None)
-    add_sub_element(doc, art, 'background', str(background) if background else None)
+    add_sub_element(doc, art, 'poster', re.search(r'.*/(.*)', str(poster)).group(1) if poster else None)
+    add_sub_element(doc, art, 'background', re.search(r'.*/(.*)', str(background)).group(1) if background else None)
 
     if config.enable_metadataapi_genres:
         add_all_sub_element(doc, root, 'genre', info.tags)
@@ -120,6 +122,7 @@ def write_movie_xml_file(info: LookedUpFileInfo, config: NamerConfig, trailer: O
 
     add_sub_element(doc, root, 'studio', info.site)
     add_sub_element(doc, root, 'theporndbid', str(info.uuid))
+    add_sub_element(doc, root, 'theporndbguid', str(info.guid))
     add_sub_element(doc, root, 'phoenixadultid')
     add_sub_element(doc, root, 'phoenixadulturlid')
 
@@ -130,7 +133,7 @@ def write_movie_xml_file(info: LookedUpFileInfo, config: NamerConfig, trailer: O
         actor = add_sub_element(doc, root, 'actor')
         add_sub_element(doc, actor, 'name', performer.name)
         add_sub_element(doc, actor, 'role', performer.role)
-        add_sub_element(doc, actor, 'image', str(performer.image) if performer.image else None)
+        add_sub_element(doc, actor, 'image', re.search(r'.*/(.*)', str(performer.image)).group(1) if performer.image else None)
         add_sub_element(doc, actor, 'type', "Actor")
         add_sub_element(doc, actor, 'thumb')
 

--- a/namer/namer.py
+++ b/namer/namer.py
@@ -228,9 +228,9 @@ def add_extra_artifacts(video_file: Path, new_metadata: LookedUpFileInfo, search
         poster = get_image(new_metadata.poster_url, "-poster", video_file, config)
         background = get_image(new_metadata.background_url, "-background", video_file, config)
         for performer in new_metadata.performers:
-            poster = get_image(performer.image, performer.name.replace(" ", "-") + "-image", video_file, config)
-            if poster is not None:
-                performer.image = str(poster)
+            performerimage = get_image(performer.image, "-Performer-" + performer.name.replace(" ", "-") + "-image", video_file, config)
+            if performerimage is not None:
+                performer.image = str(performerimage)
 
         write_nfo(video_file, new_metadata, config, trailer, poster, background, phash)
 


### PR DESCRIPTION
Adding <tpdbguid> for GUID/StashID
Fix for <poster> being populated by performer image instead of actual poster
Remove path from image names in NFO
Change for performer image filenames to now be `{TITLE}-Performer-{Performer}-image`. Previously the Performer name was directly concatenated to the end of the scene rename format