### PR TITLE
Update namer.cfg.default

### DIFF
--- a/namer/configuration.py
+++ b/namer/configuration.py
@@ -277,7 +277,7 @@ class NamerConfig:
     running server that responds like tpdb to predefined queries.
     """
 
-    enabled_tagging: bool = True
+    enabled_tagging: bool = False
     """
     Currently metadata pulled from the porndb can be added to mp4 files.
     This metadata will be read in fully by Plex, and Apple TV app, partially by Jellyfin (no artist support).
@@ -288,7 +288,7 @@ class NamerConfig:
     No flags in this section will be used if this is not set to true.
     """
 
-    enabled_poster: bool = True
+    enabled_poster: bool = False
     """
     Should the poster fetched from the porn db be written in to the metadata of the mp4.
     This poster will be displayed in Plex, Jellyfin and Apple TV app.

--- a/namer/namer.cfg.default
+++ b/namer/namer.cfg.default
@@ -143,7 +143,7 @@ override_tpdb_address =
 # Without modify the enconding where possible covert container (aka file types) to this
 # desired container type ("mp4", "mkv", "avi", ect), plugged in to the command:
 # "ffmpeg -i input.mkv -c copy output.<type>"
-convert_container_to = 
+convert_container_to =
 
 [Phash]
 # Calculate and use phashes in search for matches

--- a/namer/namer.cfg.default
+++ b/namer/namer.cfg.default
@@ -176,12 +176,12 @@ use_gpu = False
 write_nfo = False
 
 # Should metadata fetched from the porn db be written in to the metadata of the mp4.
-enabled_tagging = True
+enabled_tagging = False
 
 # Should the poster fetched from the porn db be written in to the metadata of the mp4.
 # This poster will be displayed in Plex, Jellyfin and Apple TV app.
 # Controls downloading of images for .nfo and mp4 tagging.
-enabled_poster = True
+enabled_poster = False
 
 # List of which images would be downloaded options are: poster,background,performer
 download_type = poster,background,performer

--- a/test/namer_test.py
+++ b/test/namer_test.py
@@ -78,6 +78,8 @@ class UnitTestAsTheDefaultExecution(unittest.TestCase):
         Test renaming and writing a movie's metadata from a nfo file.
         """
         config = sample_config()
+        config.enabled_tagging = True
+        config.enabled_poster = True
         config.write_nfo = False
         config.min_file_size = 0
         with tempfile.TemporaryDirectory(prefix="test") as tmpdir:

--- a/test/namer_types_test.py
+++ b/test/namer_types_test.py
@@ -34,7 +34,7 @@ class UnitTestAsTheDefaultExecution(unittest.TestCase):
         config = NamerConfig()
         self.assertEqual(config.del_other_files, False)
         self.assertEqual(config.inplace_name, "{full_site} - {date} - {name} [WEBDL-{resolution}].{ext}")
-        self.assertEqual(config.enabled_tagging, True)
+        self.assertEqual(config.enabled_tagging, False)
         self.assertEqual(config.write_namer_log, False)
         self.assertEqual(config.enable_metadataapi_genres, False)
         self.assertEqual(config.default_genre, "Adult")

--- a/test/utils.py
+++ b/test/utils.py
@@ -223,6 +223,8 @@ def environment(config: NamerConfig = None):  # type: ignore
     with tempfile.TemporaryDirectory(prefix="test") as tmpdir, FakeTPDB() as fakeTpdb:
         tempdir = Path(tmpdir)
 
+        config.enabled_tagging = True
+        config.enabled_poster = True
         config.override_tpdb_address = fakeTpdb.get_url()
         config.watch_dir = tempdir / "watch"
         config.watch_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Updating due to oshash being poisoned for stash. Stash uses oshash for matching purposes and having tagging on by default will ruin files for stash.