### PR TITLE
add replacement for source file name

### DIFF
--- a/namer/comparison_results.py
+++ b/namer/comparison_results.py
@@ -231,6 +231,7 @@ class LookedUpFileInfo:
             'performers': ', '.join(map(lambda p: p.name, filter(lambda p: p.role == 'Female', self.performers))) if self.performers else None,
             'all_performers': ', '.join(map(lambda p: p.name, self.performers)) if self.performers else None,
             'ext': self.original_parsed_filename.extension if self.original_parsed_filename else None,
+            'source_file_name': self.original_parsed_filename.source_file_name if self.original_parsed_filename else None,
             'trans': self.original_parsed_filename.trans if self.original_parsed_filename else None,
             'vr': vr,
             'resolution': res_str,

--- a/namer/name_formatter.py
+++ b/namer/name_formatter.py
@@ -25,6 +25,7 @@ class PartialFormatter(string.Formatter):
         'act',
         'ext',
         'trans',
+        'source_file_name',
         'uuid',
         'vr',
         'type',

--- a/namer/namer.cfg.default
+++ b/namer/namer.cfg.default
@@ -42,6 +42,7 @@ name_parser = {_site}{_sep}{_optional_date}{_ts}{_name}{_dot}{_ext}
 # * 'all_performers' - comma seperated list of all performers
 # * 'act' - an act, parsed from original file name, don't use.
 # * 'ext' - original file's extension, you should keep this.
+# * 'source_file_name' - original file name
 # * 'video_codec' - video codec of file, like h264
 # * 'audio_codec' - audio codec of file, like acc
 # * 'trans' - 'TS', or 'ts' if detected in original file name.


### PR DESCRIPTION
This adds the original filename as an replacement `source_file_name`.

See also #97.